### PR TITLE
Fixed functions that return arrays and functions that deal with FANN::connection arrays

### DIFF
--- a/fann2/fann2.i
+++ b/fann2/fann2.i
@@ -15,7 +15,7 @@
 #include "fann_cpp_subclass.h"
 %}
 
-%define HELPER_ARRAY_TEMPLATE( templ , T, GetFunc, SetFunc, cast) 
+%define HELPER_ARRAY_TEMPLATE( templ , T, GetFunc, SetFunc, cast)
     %typemap(in) templ<T> *  (templ<T> temp){
         // templ<T>* type_map in
         int i;
@@ -35,7 +35,7 @@
             if (PyNumber_Check(o)) {
                 $1->array[i] = (T) GetFunc(o);
             } else {
-                PyErr_SetString(PyExc_ValueError,"Sequence elements must be numbers");      
+                PyErr_SetString(PyExc_ValueError,"Sequence elements must be numbers");
                 Py_DECREF(o);
                 SWIG_fail;
             }
@@ -44,8 +44,8 @@
     }
 %typemap(freearg) templ<T>* {
     // templ<T>* type_map freearg
-    if ($1 && $1->array && $1->can_delete) 
-    {	
+    if ($1 && $1->array && $1->can_delete)
+    {
         free($1->array);
     }
 }
@@ -53,13 +53,13 @@
 %typemap(out) templ<T>* {
     // templ* type_map out
     $result= PyList_New( $1->array_len );
-    for (unsigned int i = 0; i < $1->array_len; i++) 
+    for (unsigned int i = 0; i < $1->array_len; i++)
     {
         PyObject *o = SetFunc( (cast) $1->array[i]);
         PyList_SetItem($result,i,o);
     }
-    if ($1 && $1->array && $1->can_delete) 
-    {	
+    if ($1 && $1->array && $1->can_delete)
+    {
         free($1->array);
     }
     if ($1) delete $1;
@@ -67,10 +67,10 @@
 
 %enddef
 
-%define HELPER_ARRAY_ARRAY_TEMPLATE(templ, T,  GetFunc, SetFunc, cast) 
+%define HELPER_ARRAY_ARRAY_TEMPLATE(templ, T,  GetFunc, SetFunc, cast)
 %typemap(in) templ< T >* ( templ<T> temp) {
     // templ<T>* type_map
-    unsigned int i;  
+    unsigned int i;
     unsigned int j;
     unsigned int dim;
     unsigned int num;
@@ -85,7 +85,7 @@
     $1=&temp;
     num=PySequence_Length($input);
     $1->array_num=num;
-    
+
     PyObject* o0=PySequence_GetItem($input,0);
     if (!PySequence_Check(o0)) {
         PyErr_SetString(PyExc_ValueError,"Expected an inner sequence");
@@ -94,10 +94,10 @@
     }
     dim=PySequence_Length(o0);
     Py_DECREF(o0);
-    
+
     $1->array_len=dim;
     $1->arrays = (T **) calloc(num,sizeof(T*));
-  
+
     for (j = 0; j< num; j++)
     {
         PyObject* o1=PySequence_GetItem($input,j);
@@ -117,7 +117,7 @@
             if (PyNumber_Check(o)) {
                 $1->arrays[j][i] = (T) GetFunc(o);
             } else {
-                PyErr_SetString(PyExc_ValueError,"Sequence elements must be numbers");      
+                PyErr_SetString(PyExc_ValueError,"Sequence elements must be numbers");
                 Py_DECREF(o);
                 Py_DECREF(o1);
                 SWIG_fail;
@@ -130,10 +130,10 @@
 %typemap(freearg) templ< T >* {
     // templ* type_map freearg
     unsigned int i;
-    if ($1 && $1->arrays && $1->can_delete) 
+    if ($1 && $1->arrays && $1->can_delete)
     {
         for (i=0; i < $1->array_num;++i)
-        	if ($1->arrays[i]) 
+        	if ($1->arrays[i])
                 free($1->arrays[i]);
         free($1->arrays);
     }
@@ -141,11 +141,11 @@
 %typemap(out) templ<T>* {
     // templ* type_map out
     $result= PyList_New( $1->array_num );
-    for (unsigned int j = 0; j < $1->array_num; ++j) 
+    for (unsigned int j = 0; j < $1->array_num; ++j)
     {
         PyObject *l= PyList_New( $1->array_len );
         PyList_SetItem($result,j,l);
-        for (unsigned int i = 0; i < $1->array_len; i++) 
+        for (unsigned int i = 0; i < $1->array_len; i++)
         {
             PyObject *o = SetFunc($1->arrays[j][i] );
             //PyObject *o = SetFunc($1->arrays[i][j] );
@@ -153,10 +153,10 @@
         }
     }
     unsigned int i;
-    if ($1 && $1->arrays && $1->can_delete) 
+    if ($1 && $1->arrays && $1->can_delete)
     {
         for (i=0; i < $1->array_num;++i)
-        	if ($1->arrays[i]) 
+        	if ($1->arrays[i])
                 free($1->arrays[i]);
         free($1->arrays);
     }
@@ -177,6 +177,83 @@ HELPER_ARRAY_TEMPLATE( FANN::helper_array, unsigned int, PyInt_AsLong    , PyInt
 HELPER_ARRAY_TEMPLATE( FANN::helper_array, fann_type   , PyFloat_AsDouble, PyFloat_FromDouble, double );
 
 HELPER_ARRAY_ARRAY_TEMPLATE( FANN::helper_array_array, fann_type   , PyFloat_AsDouble, PyFloat_FromDouble, double );
+
+
+
+// Begin typemap specialization for helper_array<connection>*.
+
+%typemap(in) FANN::helper_array<FANN::connection> *  (FANN::helper_array<FANN::connection> temp){
+    // FANN::helper_array<FANN::connection>* type_map in
+    int i;
+    if (!PySequence_Check($input)) {
+        PyErr_SetString(PyExc_ValueError,"Expected a sequence");
+        SWIG_fail;
+    }
+    if (PySequence_Length($input) == 0) {
+        PyErr_SetString(PyExc_ValueError,"Size mismatch. Expected some elements");
+        SWIG_fail;
+    }
+    $1=&temp;
+    $1->array_len=PySequence_Length($input);
+    $1->array = (FANN::connection *) malloc($1->array_len*sizeof(FANN::connection));
+    for (i = 0; i < PySequence_Length($input); i++) {
+        PyObject *o = PySequence_GetItem($input,i);
+        if (!PySequence_Check(o) || PySequence_Length(o) != 3) {
+            PyErr_SetString(PyExc_ValueError,"Connection must be a sequence of length 3");
+            SWIG_fail;
+        }
+        PyObject *from_neuron = PySequence_GetItem(o,0);
+        PyObject *to_neuron = PySequence_GetItem(o,1);
+        PyObject *weight = PySequence_GetItem(o,2);
+        if (PyInt_Check(from_neuron) && PyInt_Check(to_neuron) &&
+                PyNumber_Check(weight)) {
+            $1->array[i].from_neuron = (unsigned int) PyInt_AsLong(from_neuron);
+            $1->array[i].to_neuron = (unsigned int) PyInt_AsLong(to_neuron);
+            $1->array[i].weight = (fann_type) PyFloat_AsDouble(weight);
+        } else {
+            PyErr_SetString(PyExc_ValueError,"Connection elements must be (int, int, float)");
+            Py_DECREF(from_neuron);
+            Py_DECREF(to_neuron);
+            Py_DECREF(weight);
+            Py_DECREF(o);
+            SWIG_fail;
+        }
+        Py_DECREF(from_neuron);
+        Py_DECREF(to_neuron);
+        Py_DECREF(weight);
+        Py_DECREF(o);
+    }
+}
+
+%typemap(freearg) FANN::helper_array<connection>* {
+    // FANN::helper_array<connection>* type_map freearg
+    if ($1 && $1->array && $1->can_delete)
+    {
+        free($1->array);
+    }
+}
+
+%typemap(out) FANN::helper_array<connection>* {
+    // FANN::helper_array<connection>* type_map out
+    $result= PyList_New( $1->array_len );
+    for (unsigned int i = 0; i < $1->array_len; i++)
+    {
+        PyObject *o = PyTuple_Pack (3,
+                PyInt_FromLong( (long) ($1->array[i].from_neuron)),
+                PyInt_FromLong( (long) ($1->array[i].to_neuron)),
+                PyFloat_FromDouble( (double) ($1->array[i].weight)));
+        PyList_SetItem($result,i,o);
+    }
+    if ($1 && $1->array && $1->can_delete)
+    {
+        free($1->array);
+    }
+    if ($1) delete $1;
+}
+
+// End typemap specialization for helper_array<connection>*.
+
+
 
 %rename(neural_net_parent) FANN::neural_net;
 %rename(neural_net) FANN::Neural_net;

--- a/fann2/fann2.i
+++ b/fann2/fann2.i
@@ -63,22 +63,6 @@
         free($1->array);
     }
     if ($1) delete $1;
-  
-}
-
-%typemap(argout)  templ<T>* ARGOUT{
-    // templ* type_map out
-    $result= PyList_New( $1->array_len );
-    for (unsigned int i = 0; i < $1->array_len; i++) 
-    {
-        PyObject *o = SetFunc( (cast) $1->array[i]);
-        PyList_SetItem($result,i,o);
-    }
-    if ($1 && $1->array && $1->can_delete) 
-    {	
-        free($1->array);
-    }
-    if ($1) delete $1;
 }
 
 %enddef

--- a/fann2/fann_cpp_subclass.h
+++ b/fann2/fann_cpp_subclass.h
@@ -10,7 +10,7 @@
     The FANN namespace groups the C++ wrapper definitions */
 namespace FANN
 {
-	
+
     template <typename T>
     class helper_array
     {
@@ -30,7 +30,7 @@ namespace FANN
             unsigned int array_len;
 	    bool can_delete;
     };
-    
+
     template <typename T>
     class helper_array_array
     {
@@ -53,7 +53,7 @@ namespace FANN
             unsigned int array_num;
             bool can_delete;
     };
-	
+
     /* Forward declaration of class neural_net and training_data */
     class Neural_net;
     class Training_data;
@@ -70,7 +70,7 @@ namespace FANN
     {
     public:
         /* Constructor: training_data
-        
+
             Default constructor creates an empty neural net.
             Use <read_train_from_file>, <set_train_data> or <create_train_from_callback> to initialize.
         */
@@ -79,7 +79,7 @@ namespace FANN
         }
 
         /* Constructor: training_data
-        
+
             Copy constructor constructs a copy of the training data.
             Corresponds to the C API <fann_duplicate_train_data> function.
         */
@@ -115,7 +115,7 @@ namespace FANN
             or uses the training data for testing and related functions */
 
         /* Method: get_input
-        
+
             Returns:
                 A pointer to the array of input training data
 
@@ -131,7 +131,7 @@ namespace FANN
             else
             {
                 helper_array_array<fann_type>* ret = new helper_array_array<fann_type>;
-                
+
                 ret->arrays=train_data->input;
                 ret->array_num=train_data->num_data;
                 ret->array_len=train_data->num_input;
@@ -141,7 +141,7 @@ namespace FANN
         }
 
         /* Method: get_output
-        
+
             Returns:
                 A pointer to the array of output training data
 
@@ -158,7 +158,7 @@ namespace FANN
             else
             {
                 helper_array_array<fann_type>* ret = new helper_array_array<fann_type>;
-                
+
                 ret->arrays=train_data->output;
                 ret->array_num=train_data->num_data;
                 ret->array_len=train_data->num_output;
@@ -175,7 +175,7 @@ namespace FANN
             A copy of the data is made so there are no restrictions on the
             allocation of the input/output data and the caller is responsible
             for the deallocation of the data pointed to by input and output.
-            
+
             See also:
                 <get_input>, <get_output>
         */
@@ -183,16 +183,16 @@ namespace FANN
         void set_train_data(helper_array_array< fann_type >* input,
             helper_array_array< fann_type >* output)
         {
-            if (input->array_num!=output->array_num) 
+            if (input->array_num!=output->array_num)
             {
                 std::cerr<<"Error: input and output must have the same dimension!"<<std::endl;
                 return;
             }
             input->can_delete=true;
             output->can_delete=true;
-            
+
 	    training_data::set_train_data(input->array_num, input->array_len, input->arrays, output->array_len, output->arrays);
-        }  
+        }
 
 
     };
@@ -208,7 +208,7 @@ namespace FANN
     {
     public:
         /* Constructor: neural_net
-        
+
             Default constructor creates an empty neural net.
             Use one of the create functions to create the neural network.
 
@@ -247,7 +247,7 @@ namespace FANN
 		        <fann_create_standard>
 
 	        This function appears in FANN >= 2.0.0.
-        */ 
+        */
 
         bool create_standard_array( helper_array<unsigned int>* layers)
         {
@@ -294,14 +294,14 @@ namespace FANN
 
         /* Method: run
 
-	        Will run input through the neural network, returning an array of outputs, the number of which being 
+	        Will run input through the neural network, returning an array of outputs, the number of which being
 	        equal to the number of neurons in the output layer.
 
 	        See also:
 		        <test>, <fann_run>
 
 	        This function appears in FANN >= 1.0.0.
-        */ 
+        */
 
          helper_array<fann_type>* run(helper_array<fann_type> *input)
          {
@@ -324,15 +324,15 @@ namespace FANN
            Train one iteration with a set of inputs, and a set of desired outputs.
            This training is always incremental training (see <FANN::training_algorithm_enum>),
            since only one pattern is presented.
-           
+
            Parameters:
    	        ann - The neural network structure
    	        input - an array of inputs. This array must be exactly <fann_get_num_input> long.
    	        desired_output - an array of desired outputs. This array must be exactly <fann_get_num_output> long.
-           	
+
    	        See also:
    		        <train_on_data>, <train_epoch>, <fann_train>
-           	
+
    	        This function appears in FANN >= 1.0.0.
          */
 
@@ -351,12 +351,12 @@ namespace FANN
            Test with a set of inputs, and a set of desired outputs.
            This operation updates the mean square error, but does not
            change the network in any way.
-           
+
            See also:
    		        <test_data>, <train>, <fann_test>
-           
+
            This function appears in FANN >= 1.0.0.
-        */ 
+        */
 
          helper_array<fann_type>* test(helper_array<fann_type> *input, helper_array<fann_type>* desired_output)
          {
@@ -393,7 +393,7 @@ namespace FANN
             {
                 helper_array<unsigned int>* res= new helper_array<unsigned int>;
                 res->array_len = fann_get_num_layers(ann);
-                res->array = (unsigned int*) malloc(sizeof(unsigned int)* 
+                res->array = (unsigned int*) malloc(sizeof(unsigned int)*
                         res->array_len);
                 res->can_delete = true;
                 fann_get_layer_array(ann, res->array);
@@ -422,7 +422,7 @@ namespace FANN
             {
                 helper_array<unsigned int>* res= new helper_array<unsigned int>;
                 res->array_len = fann_get_num_layers(ann);
-                res->array = (unsigned int*) malloc(sizeof(unsigned int)* 
+                res->array = (unsigned int*) malloc(sizeof(unsigned int)*
                         res->array_len);
                 res->can_delete = true;
                 fann_get_bias_array(ann, res->array);
@@ -435,25 +435,28 @@ namespace FANN
 
         /* Method: get_connection_array
 
-            Get the connections in the network.
-
-            The connections array must be preallocated to at least
-            sizeof(struct fann_connection) * get_total_connections() long.
+            Return the connections in the network.
 
             See also:
                 <fann_get_connection_array>
 
            This function appears in FANN >= 2.1.0
         */
-	
-        void get_connection_array(helper_array<connection> *ARGOUT)
+
+        helper_array<connection>* get_connection_array()
         {
             if (ann != NULL)
             {
-                ARGOUT->array_len = fann_get_total_connections(ann); 
-                ARGOUT->array = (connection*) malloc(sizeof(connection)* 
-                        ARGOUT->array_len);
-                fann_get_connection_array(ann, ARGOUT->array);
+                helper_array<connection>* res= new helper_array<connection>;
+                res->array_len = fann_get_total_connections(ann);
+                res->array = (connection*) malloc(sizeof(connection)*
+                        res->array_len);
+                res->can_delete = true;
+                fann_get_connection_array(ann, res->array);
+                return res;
+            }
+            else {
+                return NULL;
             }
         }
         /* Method: set_weight_array
@@ -484,11 +487,11 @@ namespace FANN
         /* Method: get_cascade_activation_functions
 
            The cascade activation functions array is an array of the different activation functions used by
-           the candidates. 
-           
-           See <get_cascade_num_candidates> for a description of which candidate neurons will be 
+           the candidates.
+
+           See <get_cascade_num_candidates> for a description of which candidate neurons will be
            generated by this array.
-           
+
            See also:
    		        <get_cascade_activation_functions_count>, <set_cascade_activation_functions>,
    		        <FANN::activation_function_enum>
@@ -510,7 +513,7 @@ namespace FANN
            Sets the array of cascade candidate activation functions. The array must be just as long
            as defined by the count.
 
-           See <get_cascade_num_candidates> for a description of which candidate neurons will be 
+           See <get_cascade_num_candidates> for a description of which candidate neurons will be
            generated by this array.
 
            See also:
@@ -535,7 +538,7 @@ namespace FANN
            The cascade activation steepnesses array is an array of the different activation functions used by
            the candidates.
 
-           See <get_cascade_num_candidates> for a description of which candidate neurons will be 
+           See <get_cascade_num_candidates> for a description of which candidate neurons will be
            generated by this array.
 
            The default activation steepnesses is {0.25, 0.50, 0.75, 1.00}
@@ -555,14 +558,14 @@ namespace FANN
                 activation_steepnesses->array = fann_get_cascade_activation_steepnesses(ann);
             }
             return activation_steepnesses;
-        }																
+        }
 
         /* Method: set_cascade_activation_steepnesses
 
            Sets the array of cascade candidate activation steepnesses. The array must be just as long
            as defined by the count.
 
-           See <get_cascade_num_candidates> for a description of which candidate neurons will be 
+           See <get_cascade_num_candidates> for a description of which candidate neurons will be
            generated by this array.
 
            See also:

--- a/fann2/fann_cpp_subclass.h
+++ b/fann2/fann_cpp_subclass.h
@@ -377,12 +377,9 @@ namespace FANN
 
         /* Method: get_layer_array
 
-            Get the number of neurons in each layer in the network.
+            Return the number of neurons in each layer in the network.
 
             Bias is not included so the layers match the create methods.
-
-            The layers array must be preallocated to at least
-            sizeof(unsigned int) * get_num_layers() long.
 
             See also:
                 <fann_get_layer_array>
@@ -390,14 +387,20 @@ namespace FANN
            This function appears in FANN >= 2.1.0
         */
 
-        void get_layer_array(helper_array<unsigned int>* ARGOUT)
+        helper_array<unsigned int>* get_layer_array()
         {
             if (ann != NULL)
             {
-                ARGOUT->array_len = fann_get_num_layers(ann);
-                ARGOUT->array = (unsigned int*) malloc(sizeof(unsigned int)* 
-                        ARGOUT->array_len);
-                fann_get_layer_array(ann, ARGOUT->array);
+                helper_array<unsigned int>* res= new helper_array<unsigned int>;
+                res->array_len = fann_get_num_layers(ann);
+                res->array = (unsigned int*) malloc(sizeof(unsigned int)* 
+                        res->array_len);
+                res->can_delete = true;
+                fann_get_layer_array(ann, res->array);
+                return res;
+            }
+            else {
+                return NULL;
             }
         }
 
@@ -413,14 +416,20 @@ namespace FANN
 
             This function appears in FANN >= 2.1.0
         */
-        void get_bias_array(helper_array<unsigned int>* ARGOUT)
+        helper_array<unsigned int>* get_bias_array()
         {
             if (ann != NULL)
             {
-                ARGOUT->array_len = fann_get_num_layers(ann);
-                ARGOUT->array = (unsigned int*) malloc(sizeof(unsigned int)* 
-                        ARGOUT->array_len);
-                fann_get_bias_array(ann, ARGOUT->array);
+                helper_array<unsigned int>* res= new helper_array<unsigned int>;
+                res->array_len = fann_get_num_layers(ann);
+                res->array = (unsigned int*) malloc(sizeof(unsigned int)* 
+                        res->array_len);
+                res->can_delete = true;
+                fann_get_bias_array(ann, res->array);
+                return res;
+            }
+            else {
+                return NULL;
             }
         }
 


### PR DESCRIPTION
The two member functions `get_layers_array` and `get_bias_array` expected a Python list as an output argument. This has been modified so that they now return lists directly, making the interface a lot more reasonable for Python programmers.

Additionally, the member functions `get_connection_array` and `set_weights_array` could not be used since there was no SWIG interface for arrays of `FANN::connection` structs.
This interface as been added; and, on the side, the signature of `get_connection_array` has been modified as described above.
For reference: `set_weights_array` now expects a list of tuples `(from_neuron, to_neuron, weight)`, whereas `get_connection_array` returns a list of such tuples.

Running these functions on my computer didn't reveal any memory leaks.
Still, my lack of knowledge in C and C++ programming might advise to carefully check my additions.
